### PR TITLE
Truncate message private pub token after publish authentication. 

### DIFF
--- a/lib/private_pub/faye_extension.rb
+++ b/lib/private_pub/faye_extension.rb
@@ -25,6 +25,8 @@ module PrivatePub
         raise Error, "No secret_token config set, ensure private_pub.yml is loaded properly."
       elsif message["ext"]["private_pub_token"] != PrivatePub.config[:secret_token]
         message["error"] = "Incorrect token."
+      else
+        message["ext"]["private_pub_token"] = nil
       end
     end
   end

--- a/spec/private_pub/faye_extension_spec.rb
+++ b/spec/private_pub/faye_extension_spec.rb
@@ -54,4 +54,13 @@ describe PrivatePub::FayeExtension do
     message = @faye.incoming(@message, lambda { |m| m })
     message["error"].should be_nil
   end
+  
+  it "should not let message carry the private pub token after server's validation" do
+    PrivatePub.config[:secret_token] = "good"
+    @message["channel"] = "/custom/channel"
+    @message["ext"]["private_pub_token"] = PrivatePub.config[:secret_token]
+    message = @faye.incoming(@message, lambda { |m| m })
+    message['ext']["private_pub_token"].should be_nil    
+  end
+    
 end


### PR DESCRIPTION
This is to prevent the private token from being revealed on client side
