### PR TITLE
Publishing from controllers etc.

### DIFF
--- a/lib/private_pub.rb
+++ b/lib/private_pub.rb
@@ -33,6 +33,14 @@ module PrivatePub
       Net::HTTP.post_form(URI.parse(config[:server]), data)
     end
 
+    def publish_to(channel, object = nil, &block)
+      message = {:channel => channel, :data => {:channel => channel}, :ext => {:private_pub_token => PrivatePub.config[:secret_token]}}
+      message[:data][:eval] = capture(&block) if block_given?
+      message[:data][:data] = object if object
+      PrivatePub.publish(:message => message.to_json)
+    end
+
+
     def faye_extension
       FayeExtension.new
     end

--- a/lib/private_pub/view_helpers.rb
+++ b/lib/private_pub/view_helpers.rb
@@ -1,10 +1,7 @@
 module PrivatePub
   module ViewHelpers
     def publish_to(channel, object = nil, &block)
-      message = {:channel => channel, :data => {:channel => channel}, :ext => {:private_pub_token => PrivatePub.config[:secret_token]}}
-      message[:data][:eval] = capture(&block) if block_given?
-      message[:data][:data] = object if object
-      PrivatePub.publish(:message => message.to_json)
+      PrivatePub.publish_to(channel, object, &block)
     end
 
     def subscribe_to(channel)


### PR DESCRIPTION
move publish_to to PrivatePub.publish_to which allows for publishing from controllers etc.

The publish_to view helper still exists. fixes #15
