### PR TITLE
Fix spec errors when using recent versions of Jasmine

### DIFF
--- a/private_pub.gemspec
+++ b/private_pub.gemspec
@@ -10,8 +10,9 @@ Gem::Specification.new do |s|
   s.files        = Dir["{lib,spec}/**/*", "[A-Z]*", "init.rb"] - ["Gemfile.lock"]
   s.require_path = "lib"
 
+  s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.1.0'
-  s.add_development_dependency 'jasmine'
+  s.add_development_dependency 'jasmine', '>= 1.1.1'
 
   s.rubyforge_project = s.name
   s.required_rubygems_version = ">= 1.3.4"

--- a/spec/javascripts/support/jasmine_runner.rb
+++ b/spec/javascripts/support/jasmine_runner.rb
@@ -4,7 +4,7 @@ require 'rubygems'
 require 'jasmine'
 jasmine_config_overrides = File.expand_path(File.join(File.dirname(__FILE__), 'jasmine_config.rb'))
 require jasmine_config_overrides if File.exist?(jasmine_config_overrides)
-if Jasmine::rspec2?
+if Jasmine::Dependencies.rspec2?
   require 'rspec'
 else
   require 'spec'
@@ -15,7 +15,7 @@ spec_builder = Jasmine::SpecBuilder.new(jasmine_config)
 
 should_stop = false
 
-if Jasmine::rspec2?
+if Jasmine::Dependencies.rspec2?
   RSpec.configuration.after(:suite) do
     spec_builder.stop if should_stop
   end


### PR DESCRIPTION
Greetings,

Starting in version 1.1.1, the Jasmine gem moved the `rspec2?` method out of `Jasmine` and into `Jasmine::Dependencies`. This pull request specifies at least version 1.1.1 of Jasmine in the development dependencies and also uses the new namespace in the Jasmine runner.

Thanks!
