### PR TITLE
Missing HTTPS require

### DIFF
--- a/lib/private_pub.rb
+++ b/lib/private_pub.rb
@@ -1,5 +1,6 @@
 require "digest/sha1"
 require "net/http"
+require "net/https"
 
 require "private_pub/faye_extension"
 require "private_pub/engine" if defined? Rails


### PR DESCRIPTION
It seems that in some cases this require is necessary for the use_ssl attribute to be available.
