### PR TITLE
Use an initializer instead of an yaml file for configurations 

### DIFF
--- a/lib/generators/private_pub/install_generator.rb
+++ b/lib/generators/private_pub/install_generator.rb
@@ -6,6 +6,7 @@ module PrivatePub
       end
 
       def copy_files
+        template "private_pub.yml", "config/private_pub.yml"
         template "private_pub.rb", "config/initializers/private_pub.rb"
         if ::Rails.version < "3.1"
           copy_file "../../../../app/assets/javascripts/private_pub.js", "public/javascripts/private_pub.js"

--- a/lib/generators/private_pub/templates/private_pub.rb
+++ b/lib/generators/private_pub/templates/private_pub.rb
@@ -1,6 +1,7 @@
 # Use this setup block to configure all options available in PrivatePub.
 PrivatePub.setup do |private_pub|
-  private_pub.config['server'] = 'http://localhost:9292/faye'
-  private_pub.config['secret_token'] = '<%= defined?(SecureRandom) ? SecureRandom.hex(32) : ActiveSupport::SecureRandom.hex(32) %>'
-  private_pub.config['signature_expiration'] = 3600 # one hour
+  # By default, all configuration is loaded from config/private_pub.yml.
+  # Be sure to also change your private_pub.ru file if you modify this behavior.
+  path = Rails.root.join("config/private_pub.yml")
+  PrivatePub.load_config(path, Rails.env) if path.exist?
 end

--- a/lib/generators/private_pub/templates/private_pub.yml
+++ b/lib/generators/private_pub/templates/private_pub.yml
@@ -1,0 +1,10 @@
+development:
+  server: "http://localhost:9292/faye"
+  secret_token: "secret"
+test:
+  server: "http://localhost:9292/faye"
+  secret_token: "secret"
+production:
+  server: "http://example.com/faye"
+  secret_token: "<%= defined?(SecureRandom) ? SecureRandom.hex(32) : ActiveSupport::SecureRandom.hex(32) %>"
+  signature_expiration: 3600 # one hour

--- a/lib/private_pub.rb
+++ b/lib/private_pub.rb
@@ -16,6 +16,13 @@ module PrivatePub
       @config = {}
     end
 
+    # Loads the  configuration from a given YAML file and environment (such as production)     
+    def load_config(filename, environment)
+      yaml = YAML.load_file(filename)[environment.to_s]
+      raise ArgumentError, "The #{environment} environment does not exist in #{filename}" if yaml.nil?
+      yaml.each { |k, v| config[k.to_sym] = v }
+    end
+
     # Publish the given data to a specific channel. This ends up sending
     # a Net::HTTP POST request to the Faye server.
     def publish_to(channel, data)
@@ -24,7 +31,7 @@ module PrivatePub
 
     # Sends the given message hash to the Faye server using Net::HTTP.
     def publish_message(message)
-      raise Error, "No server specified, ensure private_pub.rb initializer was loaded properly." unless config[:server]
+      raise Error, "No server specified, ensure your private_pub configuration was loaded properly." unless config[:server]
       url = URI.parse(config[:server])
 
       form = Net::HTTP::Post.new(url.path.empty? ? '/' : url.path)

--- a/spec/fixtures/private_pub.yml
+++ b/spec/fixtures/private_pub.yml
@@ -1,0 +1,8 @@
+development:
+  server: http://dev.local:9292/faye
+  secret_token: DEVELOPMENT_SECRET_TOKEN
+  signature_expiration: 600
+production:
+  server: http://example.com/faye
+  secret_token: PRODUCTION_SECRET_TOKEN
+  signature_expiration: 600

--- a/spec/private_pub_spec.rb
+++ b/spec/private_pub_spec.rb
@@ -19,6 +19,18 @@ describe PrivatePub do
     PrivatePub.subscription[:timestamp].should eq((time.to_f * 1000).round)
   end
 
+  it "loads a simple configuration file via load_config" do      
+    PrivatePub.load_config("spec/fixtures/private_pub.yml", "production")
+    PrivatePub.config[:server].should eq("http://example.com/faye")
+    PrivatePub.config[:secret_token].should eq("PRODUCTION_SECRET_TOKEN")
+    PrivatePub.config[:signature_expiration].should eq(600)
+  end
+  
+  it "raises an exception if an invalid environment is passed to load_config" do
+    lambda {
+      PrivatePub.load_config("spec/fixtures/private_pub.yml", :test)
+    }.should raise_error ArgumentError
+  end
 
   it 'yields self in setup block' do
     PrivatePub.setup do |private_pub|


### PR DESCRIPTION
First of all, thanks for this awesome gem!

In this commit I've moved the `PrivatePub.load_config` call to an initalizer .rb file, generated by running `rails generate private_pub:install`. I think an intializer under your project tree is a better approach than an initializer in a `Rails::Engine`, because it enables you to perform several customizations in the way the settings are loaded. Think about a rails app that already defines its own config file and you want to avoid duplicates, and so on.

Well, it's just an idea. Even if you don't approve these changes, I would appreciate your comments.

Thanks.
