### PR TITLE
Allow environment variables in the configuration file

### DIFF
--- a/lib/generators/private_pub/templates/private_pub.ru
+++ b/lib/generators/private_pub/templates/private_pub.ru
@@ -4,7 +4,7 @@ require "yaml"
 require "faye"
 require "private_pub"
 
-Faye::WebSocket.load_adapter('puma')
+Faye::WebSocket.load_adapter('thin')
 
 PrivatePub.load_config(File.expand_path("../config/private_pub.yml", __FILE__), ENV["RAILS_ENV"] || "development")
 run PrivatePub.faye_app

--- a/lib/generators/private_pub/templates/private_pub.ru
+++ b/lib/generators/private_pub/templates/private_pub.ru
@@ -4,7 +4,7 @@ require "yaml"
 require "faye"
 require "private_pub"
 
-Faye::WebSocket.load_adapter('thin')
+Faye::WebSocket.load_adapter('puma')
 
 PrivatePub.load_config(File.expand_path("../config/private_pub.yml", __FILE__), ENV["RAILS_ENV"] || "development")
 run PrivatePub.faye_app

--- a/lib/private_pub.rb
+++ b/lib/private_pub.rb
@@ -18,7 +18,7 @@ module PrivatePub
 
     # Loads the  configuration from a given YAML file and environment (such as production)
     def load_config(filename, environment)
-      yaml = YAML.load_file(filename)[environment.to_s]
+      yaml = YAML.load(ERB.new(File.read(filename)).result)[environment.to_s]
       raise ArgumentError, "The #{environment} environment does not exist in #{filename}" if yaml.nil?
       yaml.each { |k, v| config[k.to_sym] = v }
     end

--- a/lib/private_pub.rb
+++ b/lib/private_pub.rb
@@ -4,6 +4,7 @@ require "net/https"
 
 require "private_pub/faye_extension"
 require "private_pub/engine" if defined? Rails
+require "yaml"
 
 module PrivatePub
   class Error < StandardError; end
@@ -21,6 +22,7 @@ module PrivatePub
       yaml = YAML.load(ERB.new(File.read(filename)).result)[environment.to_s]
       raise ArgumentError, "The #{environment} environment does not exist in #{filename}" if yaml.nil?
       yaml.each { |k, v| config[k.to_sym] = v }
+      config[:signature_expiration] = config[:signature_expiration].to_i if config[:signature_expiration] && !config[:signature_expiration].is_a?(Integer)
     end
 
     # Publish the given data to a specific channel. This ends up sending

--- a/private_pub.gemspec
+++ b/private_pub.gemspec
@@ -1,11 +1,11 @@
 Gem::Specification.new do |s|
   s.name        = "private_pub"
-  s.version     = "1.0.3"
+  s.version     = "1.0.4"
   s.author      = "Ryan Bates"
   s.email       = "ryan@railscasts.com"
   s.homepage    = "http://github.com/ryanb/private_pub"
   s.summary     = "Private pub/sub messaging in Rails."
-  s.description = "Private pub/sub messaging in Rails through Faye."
+  s.description = "Private pub/sub messaging in Rails through Faye with command env params and puma."
 
   s.files        = Dir["{app,lib,spec}/**/*", "[A-Z]*", "init.rb"] - ["Gemfile.lock"]
   s.require_path = "lib"

--- a/private_pub.gemspec
+++ b/private_pub.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.email       = "ryan@railscasts.com"
   s.homepage    = "http://github.com/ryanb/private_pub"
   s.summary     = "Private pub/sub messaging in Rails."
-  s.description = "Private pub/sub messaging in Rails through Faye with command env params and puma."
+  s.description = "Private pub/sub messaging in Rails through Faye with command env params."
 
   s.files        = Dir["{app,lib,spec}/**/*", "[A-Z]*", "init.rb"] - ["Gemfile.lock"]
   s.require_path = "lib"

--- a/spec/fixtures/private_pub.yml
+++ b/spec/fixtures/private_pub.yml
@@ -2,6 +2,10 @@ development:
   server: http://dev.local:9292/faye
   secret_token: DEVELOPMENT_SECRET_TOKEN
   signature_expiration: 600
+staging:
+  server: <%= ENV['FAYE_SERVER'] %>
+  secret_token: <%= ENV['FAYE_TOKEN'] %>
+  signature_expiration: <%= ENV['FAYE_EXPIRATION'] %>
 production:
   server: http://example.com/faye
   secret_token: PRODUCTION_SECRET_TOKEN

--- a/spec/private_pub_spec.rb
+++ b/spec/private_pub_spec.rb
@@ -26,6 +26,16 @@ describe PrivatePub do
     PrivatePub.config[:signature_expiration].should eq(600)
   end
 
+  it "loads a configuration file with erb tags via load_config" do
+    ENV["FAYE_SERVER"] = "http://example.com/faye"
+    ENV["FAYE_TOKEN"] = "STAGING_SECRET_TOKEN"
+    ENV["FAYE_EXPIRATION"] = "600"
+    PrivatePub.load_config("spec/fixtures/private_pub.yml", "staging")
+    PrivatePub.config[:server].should eq("http://example.com/faye")
+    PrivatePub.config[:secret_token].should eq("STAGING_SECRET_TOKEN")
+    PrivatePub.config[:signature_expiration].should eq(600)
+  end
+
   it "raises an exception if an invalid environment is passed to load_config" do
     lambda {
       PrivatePub.load_config("spec/fixtures/private_pub.yml", :test)


### PR DESCRIPTION
This eases deployment by allowing environment variables in private_pub.yml.

Because Faye needs to run in production mode, the yaml file's `production` block gets used for both development and production, making private_pub hard to deploy.

```
production:
  server: <%= ENV["FAYE_SERVER"] %>
  secret_token: <%= ENV["FAYE_KEY"] %>
```

This change also forces signature_expiration to an integer regardless of how it is entered in the configuration, and it adds tests.
