### PR TITLE
#94 Have a configuration setting to turn off http.verify_mode

### DIFF
--- a/lib/private_pub.rb
+++ b/lib/private_pub.rb
@@ -38,8 +38,11 @@ module PrivatePub
       form.set_form_data(:message => message.to_json)
 
       http = Net::HTTP.new(url.host, url.port)
-      http.use_ssl = url.scheme == "https"
-      http.start {|h| h.request(form)}
+        if url.scheme == "https"
+            http.use_ssl = true
+            http.verify_mode = OpenSSL::SSL::VERIFY_NONE if config[:ssl_verify_mode] == true
+        end
+        http.start {|h| h.request(form)}
     end
 
     # Returns a message hash for sending to Faye


### PR DESCRIPTION
Depending on your servers openssl (the server issuing the request) configuration you may also need to set the http.verify_mode option.

if url.scheme == "https"
http.use_ssl = true
http.verify_mode = OpenSSL::SSL::VERIFY_NONE if config[:ssl_verify_mode] == true
end

This gets around the "SSL not-verified" error message you get when your server can not verify the response with the certificates installed on your server. You can get your system admin to reconfigure the openssl installation or add this piece code as a work around.
