### PR TITLE
Fixed crashing when ext doesn't exist in message

### DIFF
--- a/lib/private_pub/faye_extension.rb
+++ b/lib/private_pub/faye_extension.rb
@@ -18,7 +18,7 @@ module PrivatePub
     # Ensure the subscription signature is correct and that it has not expired.
     def authenticate_subscribe(message)
       subscription = PrivatePub.subscription(:channel => message["subscription"], :timestamp => message["ext"]["private_pub_timestamp"])
-      if message["ext"]["private_pub_signature"] != subscription[:signature]
+      if message["ext"].nil? || message["ext"]["private_pub_signature"] != subscription[:signature]
         message["error"] = "Incorrect signature."
       elsif PrivatePub.signature_expired? message["ext"]["private_pub_timestamp"].to_i
         message["error"] = "Signature has expired."
@@ -29,7 +29,7 @@ module PrivatePub
     def authenticate_publish(message)
       if PrivatePub.config[:secret_token].nil?
         raise Error, "No secret_token config set, ensure private_pub.yml is loaded properly."
-      elsif message["ext"]["private_pub_token"] != PrivatePub.config[:secret_token]
+      elsif message["ext"].nil? || message["ext"]["private_pub_token"] != PrivatePub.config[:secret_token]
         message["error"] = "Incorrect token."
       else
         message["ext"]["private_pub_token"] = nil


### PR DESCRIPTION
When a user tries to use curl or some other method to post a message to the faye and doesn't have 'ext' in the data the server crashes.
This patch fixes this issue by checking the existence first
