### PR TITLE
Allow multiple callbacks per subscription, upgrade to rspec 3.2, and jasmine 2.2

### DIFF
--- a/app/assets/javascripts/private_pub.js
+++ b/app/assets/javascripts/private_pub.js
@@ -28,7 +28,7 @@ function buildPrivatePub(doc) {
       self.fayeClient.addExtension(self.fayeExtension);
       for (var i=0; i < self.fayeCallbacks.length; i++) {
         self.fayeCallbacks[i](self.fayeClient);
-      };
+      }
     },
 
     fayeExtension: {
@@ -59,11 +59,15 @@ function buildPrivatePub(doc) {
     },
 
     handleResponse: function(message) {
+      var callbacks;
       if (message.eval) {
         eval(message.eval);
       }
-      if (callback = self.subscriptionCallbacks[message.channel]) {
-        callback(message.data, message.channel);
+
+      if (callbacks = self.subscriptionCallbacks[message.channel]) {
+        callbacks.forEach(function(callback) {
+          callback(message.data, message.channel);
+        });
       }
     },
 
@@ -88,7 +92,8 @@ function buildPrivatePub(doc) {
     },
 
     subscribe: function(channel, callback) {
-      self.subscriptionCallbacks[channel] = callback;
+      self.subscriptionCallbacks[channel] = self.subscriptionCallbacks[channel] || [];
+      self.subscriptionCallbacks[channel].push(callback);
     }
   };
   return self;

--- a/lib/private_pub.rb
+++ b/lib/private_pub.rb
@@ -1,6 +1,7 @@
 require "digest/sha1"
 require "net/http"
 require "net/https"
+require "yaml"
 
 require "private_pub/faye_extension"
 require "private_pub/engine" if defined? Rails

--- a/private_pub.gemspec
+++ b/private_pub.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'faye'
 
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec', '~> 2.8.0'
-  s.add_development_dependency 'jasmine', '>= 1.1.1'
+  s.add_development_dependency 'rspec', '~> 3.2.0'
+  s.add_development_dependency 'jasmine', '~> 2.2.0'
 
   s.rubyforge_project = s.name
   s.required_rubygems_version = ">= 1.3.4"

--- a/spec/javascripts/private_pub_spec.js
+++ b/spec/javascripts/private_pub_spec.js
@@ -1,120 +1,150 @@
 describe("PrivatePub", function() {
   var pub, doc;
+
   beforeEach(function() {
     Faye = {}; // To simulate global Faye object
-    doc = {};
-    pub = buildPrivatePub(doc);
+    doc  = {};
+    pub  = buildPrivatePub(doc);
   });
 
-  it("adds a subscription callback", function() {
-    pub.subscribe("hello", "callback");
-    expect(pub.subscriptionCallbacks["hello"]).toEqual("callback");
+  it("adds a subscription callbacks", function() {
+    pub.subscribe("hello", "first-callback");
+    pub.subscribe("hello", "second-callback");
+
+    expect(pub.subscriptionCallbacks.hello).toEqual(["first-callback", "second-callback"]);
   });
 
   it("has a fayeExtension which adds matching subscription signature and timestamp to outgoing message", function() {
-    var called = false;
-    var message = {channel: "/meta/subscribe", subscription: "hello"}
-    pub.subscriptions["hello"] = {signature: "abcd", timestamp: "1234"}
+    var called  = false;
+    var message = { channel: "/meta/subscribe", subscription: "hello" };
+    pub.subscriptions.hello = { signature: "abcd", timestamp: "1234" };
+
     pub.fayeExtension.outgoing(message, function(message) {
       expect(message.ext.private_pub_signature).toEqual("abcd");
       expect(message.ext.private_pub_timestamp).toEqual("1234");
       called = true;
     });
+
     expect(called).toBeTruthy();
   });
 
   it("evaluates javascript in message response", function() {
     pub.handleResponse({eval: 'self.subscriptions.foo = "bar"'});
+
     expect(pub.subscriptions.foo).toEqual("bar");
   });
 
   it("triggers callback matching message channel in response", function() {
     var called = false;
+
     pub.subscribe("test", function(data, channel) {
       expect(data).toEqual("abcd");
       expect(channel).toEqual("test");
       called = true;
     });
+
     pub.handleResponse({channel: "test", data: "abcd"});
+
     expect(called).toBeTruthy();
   });
 
   it("adds a faye subscription with response handler when signing", function() {
-    var faye = {subscribe: jasmine.createSpy()};
-    spyOn(pub, 'faye').andCallFake(function(callback) {
+    var faye    = { subscribe: jasmine.createSpy() };
+    var options = { server: "server", channel: "somechannel" };
+
+    spyOn(pub, 'faye').and.callFake(function(callback) {
       callback(faye);
     });
-    var options = {server: "server", channel: "somechannel"};
+
     pub.sign(options);
+
     expect(faye.subscribe).toHaveBeenCalledWith("somechannel", pub.handleResponse);
     expect(pub.subscriptions.server).toEqual("server");
     expect(pub.subscriptions.somechannel).toEqual(options);
   });
 
   it("adds a faye subscription with response handler when signing", function() {
-    var faye = {subscribe: jasmine.createSpy()};
-    spyOn(pub, 'faye').andCallFake(function(callback) {
+    var faye    = { subscribe: jasmine.createSpy() };
+    var options = { server: "server", channel: "somechannel" };
+
+    spyOn(pub, 'faye').and.callFake(function(callback) {
       callback(faye);
     });
-    var options = {server: "server", channel: "somechannel"};
+
     pub.sign(options);
+
     expect(faye.subscribe).toHaveBeenCalledWith("somechannel", pub.handleResponse);
     expect(pub.subscriptions.server).toEqual("server");
     expect(pub.subscriptions.somechannel).toEqual(options);
   });
 
   it("takes a callback for subscription object when signing", function(){
-    var faye = {subscribe: function(){ return "subscription"; }};
-    spyOn(pub, 'faye').andCallFake(function(callback) {
+    var faye    = { subscribe: function(){ return "subscription"; } };
+    var options = { server: "server", channel: "somechannel", subscription: jasmine.createSpy() };
+
+    spyOn(pub, 'faye').and.callFake(function(callback) {
       callback(faye);
     });
-    var options = { server: "server", channel: "somechannel" };
-    options.subscription = jasmine.createSpy();
+
     pub.sign(options);
+
     expect(options.subscription).toHaveBeenCalledWith("subscription");
   });
 
   it("returns the subscription object for a subscribed channel", function(){
-    var faye = {subscribe: function(){ return "subscription"; }};
-    spyOn(pub, 'faye').andCallFake(function(callback) {
+    var faye    = { subscribe: function(){ return "subscription"; } };
+    var options = { server: "server", channel: "somechannel" };
+
+    spyOn(pub, 'faye').and.callFake(function(callback) {
       callback(faye);
     });
-    var options = { server: "server", channel: "somechannel" };
+
     pub.sign(options);
-    expect(pub.subscription("somechannel")).toEqual("subscription")
+
+    expect(pub.subscription("somechannel")).toEqual("subscription");
   });
 
   it("unsubscribes a channel by name", function(){
-    var sub = { cancel: jasmine.createSpy() };
-    var faye = {subscribe: function(){ return sub; }};
-    spyOn(pub, 'faye').andCallFake(function(callback) {
+    var sub     = { cancel: jasmine.createSpy() };
+    var faye    = { subscribe: function(){ return sub; } };
+    var options = { server: "server", channel: "somechannel" };
+
+    spyOn(pub, 'faye').and.callFake(function(callback) {
       callback(faye);
     });
-    var options = { server: "server", channel: "somechannel" };
+
     pub.sign(options);
+
     expect(pub.subscription("somechannel")).toEqual(sub);
+
     pub.unsubscribe("somechannel");
+
     expect(sub.cancel).toHaveBeenCalled();
     expect(pub.subscription("somechannel")).toBeFalsy();
   });
 
   it("unsubscribes all channels", function(){
     var created = 0;
-    var sub = function() {
+    var faye    = { subscribe: function(){ return sub(); } };
+    var sub     = function() {
       created ++;
       var sub = { cancel: function(){ created --; } };
       return sub;
     };
-    var faye = { subscribe: function(){ return sub(); }};
-    spyOn(pub, 'faye').andCallFake(function(callback) {
+
+    spyOn(pub, 'faye').and.callFake(function(callback) {
       callback(faye);
     });
+
     pub.sign({server: "server", channel: "firstchannel"});
     pub.sign({server: "server", channel: "secondchannel"});
+
     expect(created).toEqual(2);
     expect(pub.subscription("firstchannel")).toBeTruthy();
     expect(pub.subscription("secondchannel")).toBeTruthy();
-    pub.unsubscribeAll()
+
+    pub.unsubscribeAll();
+
     expect(created).toEqual(0);
     expect(pub.subscription("firstchannel")).toBeFalsy();
     expect(pub.subscription("secondchannel")).toBeFalsy();
@@ -123,15 +153,18 @@ describe("PrivatePub", function() {
   it("triggers faye callback function immediately when fayeClient is available", function() {
     var called = false;
     pub.fayeClient = "faye";
+
     pub.faye(function(faye) {
       expect(faye).toEqual("faye");
       called = true;
     });
+
     expect(called).toBeTruthy();
   });
 
   it("adds fayeCallback when client and server aren't available", function() {
     pub.faye("callback");
+    
     expect(pub.fayeCallbacks[0]).toEqual("callback");
   });
 
@@ -140,7 +173,9 @@ describe("PrivatePub", function() {
     doc.createElement = function() { return script; };
     doc.documentElement = {appendChild: jasmine.createSpy()};
     pub.subscriptions.server = "path/to/faye";
+
     pub.faye("callback");
+
     expect(pub.fayeCallbacks[0]).toEqual("callback");
     expect(script.type).toEqual("text/javascript");
     expect(script.src).toEqual("path/to/faye.js");
@@ -149,15 +184,17 @@ describe("PrivatePub", function() {
   });
 
   it("connects to faye server, adds extension, and executes callbacks", function() {
-    callback = jasmine.createSpy();
-    client = {addExtension: jasmine.createSpy()};
+    var callback = jasmine.createSpy();
+    var client   = {addExtension: jasmine.createSpy()};
     Faye.Client = function(server) {
-      expect(server).toEqual("server")
+      expect(server).toEqual("server");
       return client;
     };
     pub.subscriptions.server = "server";
     pub.fayeCallbacks.push(callback);
+
     pub.connectToFaye();
+
     expect(pub.fayeClient).toEqual(client);
     expect(client.addExtension).toHaveBeenCalledWith(pub.fayeExtension);
     expect(callback).toHaveBeenCalledWith(client);

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -49,6 +49,7 @@ helpers:
 #   - **/*[sS]pec.js
 #
 spec_files:
+  - "**/*[Ss]pec.{js.coffee,js,coffee}"
 
 # src_dir
 #

--- a/spec/private_pub/faye_extension_spec.rb
+++ b/spec/private_pub/faye_extension_spec.rb
@@ -12,7 +12,7 @@ describe PrivatePub::FayeExtension do
     @message["ext"]["private_pub_signature"] = "bad"
     @message["ext"]["private_pub_timestamp"] = "123"
     message = @faye.incoming(@message, lambda { |m| m })
-    message["error"].should eq("Incorrect signature.")
+    expect(message["error"]).to eq("Incorrect signature.")
   end
 
   it "has no error when the signature matches the subscription" do
@@ -21,7 +21,7 @@ describe PrivatePub::FayeExtension do
     @message["ext"]["private_pub_signature"] = sub[:signature]
     @message["ext"]["private_pub_timestamp"] = sub[:timestamp]
     message = @faye.incoming(@message, lambda { |m| m })
-    message["error"].should be_nil
+    expect(message["error"]).to be_nil
   end
 
   it "has an error when signature just expired" do
@@ -31,7 +31,7 @@ describe PrivatePub::FayeExtension do
     @message["ext"]["private_pub_signature"] = sub[:signature]
     @message["ext"]["private_pub_timestamp"] = sub[:timestamp]
     message = @faye.incoming(@message, lambda { |m| m })
-    message["error"].should eq("Signature has expired.")
+    expect(message["error"]).to eq("Signature has expired.")
   end
 
   it "has an error when trying to publish to a custom channel with a bad token" do
@@ -39,21 +39,21 @@ describe PrivatePub::FayeExtension do
     @message["channel"] = "/custom/channel"
     @message["ext"]["private_pub_token"] = "bad"
     message = @faye.incoming(@message, lambda { |m| m })
-    message["error"].should eq("Incorrect token.")
+    expect(message["error"]).to eq("Incorrect token.")
   end
 
   it "raises an exception when attempting to call a custom channel without a secret_token set" do
     @message["channel"] = "/custom/channel"
     @message["ext"]["private_pub_token"] = "bad"
-    lambda {
+    expect {
       message = @faye.incoming(@message, lambda { |m| m })
-    }.should raise_error("No secret_token config set, ensure private_pub.yml is loaded properly.")
+    }.to raise_error("No secret_token config set, ensure private_pub.yml is loaded properly.")
   end
 
   it "has no error on other meta calls" do
     @message["channel"] = "/meta/connect"
     message = @faye.incoming(@message, lambda { |m| m })
-    message["error"].should be_nil
+    expect(message["error"]).to be_nil
   end
 
   it "should not let message carry the private pub token after server's validation" do
@@ -61,7 +61,7 @@ describe PrivatePub::FayeExtension do
     @message["channel"] = "/custom/channel"
     @message["ext"]["private_pub_token"] = PrivatePub.config[:secret_token]
     message = @faye.incoming(@message, lambda { |m| m })
-    message['ext']["private_pub_token"].should be_nil
+    expect(message['ext']["private_pub_token"]).to be_nil
   end
 
 end

--- a/spec/private_pub_spec.rb
+++ b/spec/private_pub_spec.rb
@@ -6,49 +6,49 @@ describe PrivatePub do
   end
 
   it "defaults server to nil" do
-    PrivatePub.config[:server].should be_nil
+    expect(PrivatePub.config[:server]).to be_nil
   end
 
   it "defaults signature_expiration to nil" do
-    PrivatePub.config[:signature_expiration].should be_nil
+    expect(PrivatePub.config[:signature_expiration]).to be_nil
   end
 
   it "defaults subscription timestamp to current time in milliseconds" do
     time = Time.now
-    Time.stub!(:now).and_return(time)
-    PrivatePub.subscription[:timestamp].should eq((time.to_f * 1000).round)
+    allow(Time).to receive(:now).and_return(time)
+    expect(PrivatePub.subscription[:timestamp]).to eq((time.to_f * 1000).round)
   end
 
   it "loads a simple configuration file via load_config" do
     PrivatePub.load_config("spec/fixtures/private_pub.yml", "production")
-    PrivatePub.config[:server].should eq("http://example.com/faye")
-    PrivatePub.config[:secret_token].should eq("PRODUCTION_SECRET_TOKEN")
-    PrivatePub.config[:signature_expiration].should eq(600)
+    expect(PrivatePub.config[:server]).to eq("http://example.com/faye")
+    expect(PrivatePub.config[:secret_token]).to eq("PRODUCTION_SECRET_TOKEN")
+    expect(PrivatePub.config[:signature_expiration]).to eq(600)
   end
 
   it "raises an exception if an invalid environment is passed to load_config" do
-    lambda {
+    expect {
       PrivatePub.load_config("spec/fixtures/private_pub.yml", :test)
-    }.should raise_error ArgumentError
+    }.to raise_error ArgumentError
   end
 
   it "includes channel, server, and custom time in subscription" do
     PrivatePub.config[:server] = "server"
     subscription = PrivatePub.subscription(:timestamp => 123, :channel => "hello")
-    subscription[:timestamp].should eq(123)
-    subscription[:channel].should eq("hello")
-    subscription[:server].should eq("server")
+    expect(subscription[:timestamp]).to eq(123)
+    expect(subscription[:channel]).to eq("hello")
+    expect(subscription[:server]).to eq("server")
   end
 
   it "does a sha1 digest of channel, timestamp, and secret token" do
     PrivatePub.config[:secret_token] = "token"
     subscription = PrivatePub.subscription(:timestamp => 123, :channel => "channel")
-    subscription[:signature].should eq(Digest::SHA1.hexdigest("tokenchannel123"))
+    expect(subscription[:signature]).to eq(Digest::SHA1.hexdigest("tokenchannel123"))
   end
 
   it "formats a message hash given a channel and a string for eval" do
     PrivatePub.config[:secret_token] = "token"
-    PrivatePub.message("chan", "foo").should eq(
+    expect(PrivatePub.message("chan", "foo")).to eq(
       :ext => {:private_pub_token => "token"},
       :channel => "chan",
       :data => {
@@ -60,7 +60,7 @@ describe PrivatePub do
 
   it "formats a message hash given a channel and a hash" do
     PrivatePub.config[:secret_token] = "token"
-    PrivatePub.message("chan", :foo => "bar").should eq(
+    expect(PrivatePub.message("chan", :foo => "bar")).to eq(
       :ext => {:private_pub_token => "token"},
       :channel => "chan",
       :data => {
@@ -73,69 +73,69 @@ describe PrivatePub do
   it "publish message as json to server using Net::HTTP" do
     PrivatePub.config[:server] = "http://localhost"
     message = 'foo'
-    form = mock(:post).as_null_object
-    http = mock(:http).as_null_object
+    form = double(:post).as_null_object
+    http = double(:http).as_null_object
 
-    Net::HTTP::Post.should_receive(:new).with('/').and_return(form)
-    form.should_receive(:set_form_data).with(message: 'foo'.to_json)
+    expect(Net::HTTP::Post).to receive(:new).with('/').and_return(form)
+    expect(form).to receive(:set_form_data).with(message: 'foo'.to_json)
 
-    Net::HTTP.should_receive(:new).with('localhost', 80).and_return(http)
-    http.should_receive(:start).and_yield(http)
-    http.should_receive(:request).with(form).and_return(:result)
+    expect(Net::HTTP).to receive(:new).with('localhost', 80).and_return(http)
+    expect(http).to receive(:start).and_yield(http)
+    expect(http).to receive(:request).with(form).and_return(:result)
 
-    PrivatePub.publish_message(message).should eq(:result)
+    expect(PrivatePub.publish_message(message)).to eq(:result)
   end
 
   it "it should use HTTPS if the server URL says so" do
     PrivatePub.config[:server] = "https://localhost"
-    http = mock(:http).as_null_object
+    http = double(:http).as_null_object
 
-    Net::HTTP.should_receive(:new).and_return(http)
-    http.should_receive(:use_ssl=).with(true)
+    expect(Net::HTTP).to receive(:new).and_return(http)
+    expect(http).to receive(:use_ssl=).with(true)
 
     PrivatePub.publish_message('foo')
   end
 
   it "it should not use HTTPS if the server URL says not to" do
     PrivatePub.config[:server] = "http://localhost"
-    http = mock(:http).as_null_object
+    http = double(:http).as_null_object
 
-    Net::HTTP.should_receive(:new).and_return(http)
-    http.should_receive(:use_ssl=).with(false)
+    expect(Net::HTTP).to receive(:new).and_return(http)
+    expect(http).to receive(:use_ssl=).with(false)
 
     PrivatePub.publish_message('foo')
   end
 
   it "raises an exception if no server is specified when calling publish_message" do
-    lambda {
+    expect {
       PrivatePub.publish_message("foo")
-    }.should raise_error(PrivatePub::Error)
+    }.to raise_error(PrivatePub::Error)
   end
 
   it "publish_to passes message to publish_message call" do
-    PrivatePub.should_receive(:message).with("chan", "foo").and_return("message")
-    PrivatePub.should_receive(:publish_message).with("message").and_return(:result)
-    PrivatePub.publish_to("chan", "foo").should eq(:result)
+    expect(PrivatePub).to receive(:message).with("chan", "foo").and_return("message")
+    expect(PrivatePub).to receive(:publish_message).with("message").and_return(:result)
+    expect(PrivatePub.publish_to("chan", "foo")).to eq(:result)
   end
 
   it "has a Faye rack app instance" do
-    PrivatePub.faye_app.should be_kind_of(Faye::RackAdapter)
+    expect(PrivatePub.faye_app).to be_kind_of(Faye::RackAdapter)
   end
 
   it "says signature has expired when time passed in is greater than expiration" do
     PrivatePub.config[:signature_expiration] = 30*60
     time = PrivatePub.subscription[:timestamp] - 31*60*1000
-    PrivatePub.signature_expired?(time).should be_true
+    expect(PrivatePub.signature_expired?(time)).to be_truthy
   end
 
   it "says signature has not expired when time passed in is less than expiration" do
     PrivatePub.config[:signature_expiration] = 30*60
     time = PrivatePub.subscription[:timestamp] - 29*60*1000
-    PrivatePub.signature_expired?(time).should be_false
+    expect(PrivatePub.signature_expired?(time)).to be_falsey
   end
 
   it "says signature has not expired when expiration is nil" do
     PrivatePub.config[:signature_expiration] = nil
-    PrivatePub.signature_expired?(0).should be_false
+    expect(PrivatePub.signature_expired?(0)).to be_falsey
   end
 end


### PR DESCRIPTION
This provides a mechanism for multiple callbacks per channel subscription (client side).

Example on the client:

```js
function updateUiElementA(data, channel) {
    ...
}

function updateUiElementB(data, channel) {
    ...
}

PrivatePub.subscribe('/something/important', updateUiElementA);
PrivatePub.subscribe('/something/important', updateUiElementB);
```

To me this is useful for scenarios as described above. Where an event happens and someone might want to update multiple UI elements with somewhat complex logic.

As an aside, I have also upgraded spec and jasmine gems. I wanted to keep the entire test suite green when making changes, in doing so I found that client side specs weren't running. I had to apply a manual pattern for spec files, and while I was at it I thought it might be a good time to bring the testing dependencies to a more current version.