### PR TITLE
prevent multiple subscriptions to same channel on same page

### DIFF
--- a/lib/private_pub/view_helpers.rb
+++ b/lib/private_pub/view_helpers.rb
@@ -15,7 +15,11 @@ module PrivatePub
     def subscribe_to(channel)
       subscription = PrivatePub.subscription(:channel => channel)
       content_tag "script", :type => "text/javascript" do
-        raw("PrivatePub.sign(#{subscription.to_json});")
+        raw ("
+          if(PrivatePub.subscriptions['#{channel}'] === undefined){
+            PrivatePub.sign(#{subscription.to_json});
+          }
+        ")
       end
     end
   end


### PR DESCRIPTION
This will prevent PrivatePub from subscribing to a channel multiple times.
